### PR TITLE
feat: enable `max-params` rule with max of 5 paramers

### DIFF
--- a/packages/eslint-config-typescript/example.ts
+++ b/packages/eslint-config-typescript/example.ts
@@ -84,3 +84,15 @@ export function overloaded(b: string): void;
 export function overloaded(_value: number | string): void {
     /* do nothing */
 }
+
+/* 5 params should be ok (excluding this) */
+export function withManyParams(
+    this: void,
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+): number[] {
+    return [a, b, c, d, e];
+}

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -31,6 +31,10 @@ module.exports = {
         /* require all members to specify "public", "private", etc */
         "@typescript-eslint/explicit-member-accessibility": "error",
 
+        /* replace base max-params rule with @typescript-eslint/max-params */
+        "max-params": "off",
+        "@typescript-eslint/max-params": ["error", { max: 5 }],
+
         /* allow "const foo: number = 0" */
         "@typescript-eslint/no-inferrable-types": "off",
 

--- a/packages/eslint-config/example.js
+++ b/packages/eslint-config/example.js
@@ -93,3 +93,8 @@ export function errorHandling() {
         }
     }
 }
+
+/* 5 params should be ok */
+export function withManyParams(a, b, c, d, e) {
+    return [a, b, c, d, e];
+}

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -31,6 +31,7 @@ module.exports = {
         curly: "error",
         eqeqeq: "error",
         "max-depth": ["error", 3],
+        "max-params": ["error", { max: 5 }],
         "no-eval": "error",
         "no-implied-eval": "error",
         "no-loop-func": "error",


### PR DESCRIPTION
Prevents functions with way to many parameters. 5 seems like a reasonable compromise, I would imagine 4 or maybe even 3 but that might be stretching it a bit.