### PR TITLE
fix: typescript config as dependency for vue config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15338,6 +15338,7 @@
       "version": "11.6.0",
       "license": "MIT",
       "dependencies": {
+        "@forsakringskassan/eslint-config-typescript": "^11.6.0",
         "eslint-plugin-vue": "9.32.0",
         "semver": "^7.0.0"
       },

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -18,6 +18,7 @@
     "index.js"
   ],
   "dependencies": {
+    "@forsakringskassan/eslint-config-typescript": "^11.6.0",
     "eslint-plugin-vue": "9.32.0",
     "semver": "^7.0.0"
   },


### PR DESCRIPTION
Vue configuration depends on TS-config, and right now you need to have both TS and Vue-config installed in order to lint vue files.
https://github.com/Forsakringskassan/eslint-config/blob/main/packages/eslint-config-vue/index.js#L18