### PR TITLE
feat: add top-level order warning (refs SB-4982)

### DIFF
--- a/packages/eslint-config-vue/example.vue
+++ b/packages/eslint-config-vue/example.vue
@@ -1,13 +1,3 @@
-<template>
-    <div v-if="myComputed">
-        <!-- @slot Slot description -->
-        <slot name="my-slot"></slot>
-    </div>
-    <div>
-        <span>{{ myComplexProp }}</span>
-    </div>
-</template>
-
 <script lang="ts">
 import type { PropType } from "vue";
 import { defineComponent } from "vue";
@@ -31,10 +21,10 @@ export default defineComponent({
          * Prop description
          */
         myComplexProp: {
-            type: Object,
+            type: Object as PropType<MyInterface>,
             required: false,
             default: () => ({}),
-        } as PropType<MyInterface>,
+        },
     },
     emits: ["change"],
     data() {
@@ -61,3 +51,13 @@ export default defineComponent({
     },
 });
 </script>
+
+<template>
+    <div v-if="myComputed">
+        <!-- @slot Slot description -->
+        <slot name="my-slot"></slot>
+    </div>
+    <div>
+        <span>{{ myComplexProp }}</span>
+    </div>
+</template>

--- a/packages/eslint-config-vue/exampleComposition.vue
+++ b/packages/eslint-config-vue/exampleComposition.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+
+// reactive state
+const count = ref(0);
+
+// functions that mutate state and trigger updates
+function increment(): void {
+    count.value++;
+}
+
+// lifecycle hooks
+onMounted(() => {
+    /* eslint-disable-next-line no-console -- expected to log */
+    console.log(`The initial count is ${count.value}.`);
+});
+</script>
+
+<template>
+    <button class="my-awesome-class" @click="increment">Count is: {{ count }}</button>
+</template>
+
+<style lang="scss" scoped>
+.my-awesome-class {
+    border: #000000;
+    color: #ffffff;
+}
+</style>

--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -36,5 +36,13 @@ module.exports = {
 
         /* documentation for vue components does not adhere with tsdoc syntax */
         "tsdoc/syntax": "off",
+
+        /* this rule warns about the order of the top-level tags */
+        "vue/block-order": [
+            "error",
+            {
+                order: ["script", "template", "style"],
+            },
+        ],
     },
 };


### PR DESCRIPTION
Lägger till regel för vilken ordning script, template och style bör ha, enligt diskussionerna på frontend-synken 2024-10-31.