### PR TITLE
fix: disable `vue/no-deprecated-slot-attribute` (refs SFKUI-6500)

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -44,5 +44,8 @@ module.exports = {
                 order: ["script", "template", "style"],
             },
         ],
+
+        /* underlying custom elements have started to expose native slots */
+        "vue/no-deprecated-slot-attribute": "off",
     },
 };


### PR DESCRIPTION
Underlying custom elements have started to expose native slots.