### PR TITLE
refactor: proper flat config for eslint-config-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15061,6 +15061,29 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.42.0.tgz",
+      "integrity": "sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.42.0",
+        "@typescript-eslint/parser": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -16271,98 +16294,16 @@
       "version": "12.1.0",
       "license": "MIT",
       "dependencies": {
-        "@eslint/eslintrc": "3.3.1",
         "@typescript-eslint/eslint-plugin": "8.42.0",
         "@typescript-eslint/parser": "8.42.0",
-        "eslint-plugin-tsdoc": "0.4.0"
+        "eslint-plugin-tsdoc": "0.4.0",
+        "typescript-eslint": "8.42.0"
       },
       "engines": {
         "node": ">= 20.19"
       },
       "peerDependencies": {
         "typescript": "^3.0.1 || ^4.0.2 || ^5.0.2"
-      }
-    },
-    "packages/eslint-config-typescript/node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/eslint-config-typescript/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "packages/eslint-config-typescript/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/eslint-config-typescript/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/eslint-config-typescript/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/eslint-config-typescript/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "packages/eslint-config-vue": {

--- a/packages/eslint-config-typescript/flat.mjs
+++ b/packages/eslint-config-typescript/flat.mjs
@@ -1,11 +1,21 @@
-import { fileURLToPath } from "node:url";
-import path from "node:path";
-import { FlatCompat } from "@eslint/eslintrc";
-import legacyConfig from "./index.cjs";
+import {
+    configs as tseConfig,
+    parser as tseParser,
+    plugin as tsePlugin,
+} from "typescript-eslint";
+import tsdocPlugin from "eslint-plugin-tsdoc";
 
 /**
  * @typedef {import("eslint").Linter.Config} Config
  */
+
+/**
+ * @param {Config} config
+ * @returns {Config}
+ */
+function defineConfig(config) {
+    return config;
+}
 
 /**
  * @param {Config} result
@@ -22,21 +32,96 @@ function merge(result, it) {
     };
 }
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const strict = tseConfig.strict.reduce(merge, {});
+const stylistic = tseConfig.stylistic.reduce(merge, {});
 
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    resolvePluginsRelativeTo: __dirname,
+const config = defineConfig({
+    name: "@forsakringskassan/eslint-config-typescript",
+    files: ["**/*.{ts,cts,mts}"],
+
+    languageOptions: {
+        parser: tseParser,
+        sourceType: "module",
+    },
+
+    plugins: {
+        "@typescript-eslint": tsePlugin,
+        tsdoc: tsdocPlugin,
+    },
+
+    rules: {
+        ...strict.rules,
+        ...stylistic.rules,
+
+        /* Disabled as it is better to let typescript deal with this. For
+         * instance, ESLint cannot detect when exhaustive checks are made and
+         * the rest of the function is dead thus yielding false positives */
+        "consistent-return": "off",
+
+        /* prefer T[] for simple types, Array<T> for complex types (unions, etc) */
+        "@typescript-eslint/array-type": ["error", { default: "array-simple" }],
+
+        /* require all regular functions and methods to explicitly declare
+         * return value type */
+        "@typescript-eslint/explicit-function-return-type": [
+            "error",
+            {
+                allowExpressions: true,
+                allowHigherOrderFunctions: true,
+                allowTypedFunctionExpressions: true,
+            },
+        ],
+
+        /* require all members to specify "public", "private", etc */
+        "@typescript-eslint/explicit-member-accessibility": "error",
+
+        /* replace base max-params rule with @typescript-eslint/max-params */
+        "max-params": "off",
+        "@typescript-eslint/max-params": ["error", { max: 5 }],
+
+        /* allow "const foo: number = 0" */
+        "@typescript-eslint/no-inferrable-types": "off",
+
+        /* allow function(this: void, ...) */
+        "@typescript-eslint/no-invalid-void-type": [
+            "error",
+            {
+                allowAsThisParameter: true,
+            },
+        ],
+
+        /* allow constructs such as `unknown | null`, while `unknown` does override
+         * `null` it can still serve as a self-documenting type to signal that
+         * `null` has a special meaning. It also helps when the type is to be
+         * replaced with a better type later. */
+        "@typescript-eslint/no-redundant-type-constituents": "off",
+
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                /* allow `foo` to be unused when `{ foo, ...spread} = bar` is
+                 * used to extract members from objects */
+                ignoreRestSiblings: true,
+
+                /* allow _ as prefix for intentionally unused variables */
+                argsIgnorePattern: "^_",
+            },
+        ],
+
+        /* allow overloading only if the parameters have different names */
+        "@typescript-eslint/unified-signatures": [
+            "error",
+            {
+                ignoreDifferentlyNamedParameters: true,
+            },
+        ],
+
+        "tsdoc/syntax": "error",
+    },
 });
-
-const migrated = compat.config(legacyConfig).reduce(merge, {});
-
-migrated.name = "@forsakringskassan/eslint-config-typescript";
-migrated.files = ["**/*.{ts,cts,mts}"];
 
 /**
  * @param {Config} [override]
  * @returns {Config}
  */
-export default (override) => merge(migrated, override ?? {});
+export default (override) => merge(config, override ?? {});

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -20,10 +20,10 @@
     "index.cjs"
   ],
   "dependencies": {
-    "@eslint/eslintrc": "3.3.1",
     "@typescript-eslint/eslint-plugin": "8.42.0",
     "@typescript-eslint/parser": "8.42.0",
-    "eslint-plugin-tsdoc": "0.4.0"
+    "eslint-plugin-tsdoc": "0.4.0",
+    "typescript-eslint": "8.42.0"
   },
   "peerDependencies": {
     "typescript": "^3.0.1 || ^4.0.2 || ^5.0.2"


### PR DESCRIPTION
Den här ska inte göra någon skillnad och config-snapshoten är identisk, den löser inte det vi pratade om häromdagen med singleton instans osv. Det är bara för att migrera till riktig flat utan att göra några andra ändringar samtidigt.