### PR TITLE
fix: enable typescript typeinfo rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import cypressConfig from "@forsakringskassan/eslint-config-cypress";
 import jestConfig from "@forsakringskassan/eslint-config-jest";
 import svelteConfig from "@forsakringskassan/eslint-config-svelte";
 import typescriptConfig from "@forsakringskassan/eslint-config-typescript";
+import typeinfoConfig from "@forsakringskassan/eslint-config-typescript-typeinfo";
 import vueConfig from "@forsakringskassan/eslint-config-vue";
 
 export default [
@@ -60,6 +61,7 @@ export default [
 
     cliConfig(),
     typescriptConfig(),
+    typeinfoConfig(import.meta.dirname),
     vueConfig(),
     jestConfig(),
     cypressConfig(),

--- a/config.test.mjs
+++ b/config.test.mjs
@@ -6,6 +6,7 @@ import cypressConfig from "./packages/eslint-config-cypress/index.mjs";
 import jestConfig from "./packages/eslint-config-jest/index.mjs";
 import svelteConfig from "./packages/eslint-config-svelte/index.mjs";
 import typescriptConfig from "./packages/eslint-config-typescript/index.mjs";
+import typeinfoConfig from "./packages/eslint-config-typescript-typeinfo/index.mjs";
 import vueConfig from "./packages/eslint-config-vue/index.mjs";
 
 /**
@@ -30,6 +31,9 @@ function serialize(value) {
         const entries = Object.entries(value);
         const mapped = entries.map(([key, it]) => {
             key = key.replace(process.cwd(), "<rootDir>");
+            if (typeof it === "string") {
+                it = it.replace(process.cwd(), "<rootDir>");
+            }
             if (key === "plugins") {
                 const pluginEntries = Object.entries(it);
                 const pluginMapped = pluginEntries.map(([key, jt]) => {
@@ -76,6 +80,7 @@ const packages = [
     "@forsakringskassan/eslint-config-jest",
     "@forsakringskassan/eslint-config-svelte",
     "@forsakringskassan/eslint-config-typescript",
+    "@forsakringskassan/eslint-config-typescript-typeinfo",
     "@forsakringskassan/eslint-config-vue",
 ];
 
@@ -90,6 +95,7 @@ for (const pkg of packages) {
 const config = [
     ...defaultConfig,
     typescriptConfig(),
+    typeinfoConfig(import.meta.dirname),
     vueConfig(),
     jestConfig(),
     cypressConfig(),

--- a/config.test.mjs.snapshot
+++ b/config.test.mjs.snapshot
@@ -723,7 +723,7 @@ exports[`Extension .cy.ts 1`] = `
     ],
     "max-params": "off",
     "no-eval": "error",
-    "no-implied-eval": "error",
+    "no-implied-eval": "off",
     "no-loop-func": "error",
     "no-new": "error",
     "no-new-func": "error",
@@ -846,7 +846,10 @@ exports[`Extension .cy.ts 1`] = `
     "@typescript-eslint/consistent-generic-constructors": "error",
     "@typescript-eslint/consistent-indexed-object-style": "error",
     "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/consistent-type-definitions": [
+      "error",
+      "interface"
+    ],
     "@typescript-eslint/no-confusing-non-null-assertion": "error",
     "no-empty-function": "off",
     "@typescript-eslint/no-empty-function": "error",
@@ -870,6 +873,98 @@ exports[`Extension .cy.ts 1`] = `
     ],
     "@typescript-eslint/no-redundant-type-constituents": "off",
     "tsdoc/syntax": "error",
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/no-array-delete": "error",
+    "@typescript-eslint/no-base-to-string": "error",
+    "@typescript-eslint/no-confusing-void-expression": "error",
+    "@typescript-eslint/no-deprecated": "error",
+    "@typescript-eslint/no-duplicate-type-constituents": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-meaningless-void-operator": "error",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksVoidReturn": {
+          "arguments": false
+        }
+      }
+    ],
+    "@typescript-eslint/no-misused-spread": "error",
+    "@typescript-eslint/no-mixed-enums": "error",
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
+    "@typescript-eslint/no-unnecessary-condition": "error",
+    "@typescript-eslint/no-unnecessary-template-expression": "error",
+    "@typescript-eslint/no-unnecessary-type-arguments": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unnecessary-type-conversion": "error",
+    "@typescript-eslint/no-unnecessary-type-parameters": "error",
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-enum-comparison": "error",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-unsafe-unary-minus": "error",
+    "no-throw-literal": "off",
+    "@typescript-eslint/only-throw-error": "error",
+    "prefer-promise-reject-errors": "off",
+    "@typescript-eslint/prefer-promise-reject-errors": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-return-this-type": "error",
+    "@typescript-eslint/related-getter-setter-pairs": "error",
+    "require-await": "off",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": false,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNever": false,
+        "allowNullish": false,
+        "allowNumber": false,
+        "allowRegExp": false
+      }
+    ],
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": [
+      "error",
+      "error-handling-correctness-only"
+    ],
+    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+    "dot-notation": "off",
+    "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/non-nullable-type-assertion-style": "error",
+    "@typescript-eslint/prefer-find": "error",
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-regexp-exec": "error",
+    "@typescript-eslint/prefer-string-starts-ends-with": "error",
+    "@typescript-eslint/consistent-type-exports": [
+      "error",
+      {
+        "fixMixedExportsWithInlineTypeSpecifier": true
+      }
+    ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "fixStyle": "inline-type-imports"
+      }
+    ],
     "cypress/no-assigning-return-values": "error",
     "cypress/no-unnecessary-waiting": "error",
     "cypress/no-async-tests": "error",
@@ -910,9 +1005,8 @@ exports[`Extension .cy.ts 1`] = `
     "ecmaVersion": 2019,
     "sourceType": "module",
     "parserOptions": {
-      "ecmaFeatures": {
-        "globalReturn": true
-      }
+      "projectService": true,
+      "tsconfigRootDir": "<rootDir>"
     },
     "parser": "[Parser typescript-eslint/parser]"
   },
@@ -2476,7 +2570,7 @@ exports[`Extension .spec.ts 1`] = `
     ],
     "max-params": "off",
     "no-eval": "error",
-    "no-implied-eval": "error",
+    "no-implied-eval": "off",
     "no-loop-func": "error",
     "no-new": "error",
     "no-new-func": "error",
@@ -2599,7 +2693,10 @@ exports[`Extension .spec.ts 1`] = `
     "@typescript-eslint/consistent-generic-constructors": "error",
     "@typescript-eslint/consistent-indexed-object-style": "error",
     "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/consistent-type-definitions": [
+      "error",
+      "interface"
+    ],
     "@typescript-eslint/no-confusing-non-null-assertion": "error",
     "no-empty-function": "off",
     "@typescript-eslint/no-empty-function": "error",
@@ -2623,6 +2720,98 @@ exports[`Extension .spec.ts 1`] = `
     ],
     "@typescript-eslint/no-redundant-type-constituents": "off",
     "tsdoc/syntax": "off",
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/no-array-delete": "error",
+    "@typescript-eslint/no-base-to-string": "error",
+    "@typescript-eslint/no-confusing-void-expression": "error",
+    "@typescript-eslint/no-deprecated": "error",
+    "@typescript-eslint/no-duplicate-type-constituents": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-meaningless-void-operator": "error",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksVoidReturn": {
+          "arguments": false
+        }
+      }
+    ],
+    "@typescript-eslint/no-misused-spread": "error",
+    "@typescript-eslint/no-mixed-enums": "error",
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
+    "@typescript-eslint/no-unnecessary-condition": "error",
+    "@typescript-eslint/no-unnecessary-template-expression": "error",
+    "@typescript-eslint/no-unnecessary-type-arguments": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unnecessary-type-conversion": "error",
+    "@typescript-eslint/no-unnecessary-type-parameters": "error",
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-enum-comparison": "error",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-unsafe-unary-minus": "error",
+    "no-throw-literal": "off",
+    "@typescript-eslint/only-throw-error": "error",
+    "prefer-promise-reject-errors": "off",
+    "@typescript-eslint/prefer-promise-reject-errors": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-return-this-type": "error",
+    "@typescript-eslint/related-getter-setter-pairs": "error",
+    "require-await": "off",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": false,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNever": false,
+        "allowNullish": false,
+        "allowNumber": false,
+        "allowRegExp": false
+      }
+    ],
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": [
+      "error",
+      "error-handling-correctness-only"
+    ],
+    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+    "dot-notation": "off",
+    "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/non-nullable-type-assertion-style": "error",
+    "@typescript-eslint/prefer-find": "error",
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-regexp-exec": "error",
+    "@typescript-eslint/prefer-string-starts-ends-with": "error",
+    "@typescript-eslint/consistent-type-exports": [
+      "error",
+      {
+        "fixMixedExportsWithInlineTypeSpecifier": true
+      }
+    ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "fixStyle": "inline-type-imports"
+      }
+    ],
     "jest/expect-expect": "warn",
     "jest/no-alias-methods": "error",
     "jest/no-commented-out-tests": "warn",
@@ -2681,9 +2870,8 @@ exports[`Extension .spec.ts 1`] = `
     "ecmaVersion": 2024,
     "sourceType": "module",
     "parserOptions": {
-      "ecmaFeatures": {
-        "globalReturn": true
-      }
+      "projectService": true,
+      "tsconfigRootDir": "<rootDir>"
     },
     "parser": "[Parser typescript-eslint/parser]"
   },
@@ -3540,7 +3728,8 @@ exports[`Extension .svelte 1`] = `
     "sourceType": "module",
     "parserOptions": {
       "extraFileExtensions": [
-        ".svelte"
+        ".svelte",
+        ".vue"
       ],
       "parser": "[Parser typescript-eslint/parser]"
     },
@@ -4296,7 +4485,7 @@ exports[`Extension .ts 1`] = `
     ],
     "max-params": "off",
     "no-eval": "error",
-    "no-implied-eval": "error",
+    "no-implied-eval": "off",
     "no-loop-func": "error",
     "no-new": "error",
     "no-new-func": "error",
@@ -4419,7 +4608,10 @@ exports[`Extension .ts 1`] = `
     "@typescript-eslint/consistent-generic-constructors": "error",
     "@typescript-eslint/consistent-indexed-object-style": "error",
     "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/consistent-type-definitions": [
+      "error",
+      "interface"
+    ],
     "@typescript-eslint/no-confusing-non-null-assertion": "error",
     "no-empty-function": "off",
     "@typescript-eslint/no-empty-function": "error",
@@ -4442,7 +4634,99 @@ exports[`Extension .ts 1`] = `
       }
     ],
     "@typescript-eslint/no-redundant-type-constituents": "off",
-    "tsdoc/syntax": "error"
+    "tsdoc/syntax": "error",
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/no-array-delete": "error",
+    "@typescript-eslint/no-base-to-string": "error",
+    "@typescript-eslint/no-confusing-void-expression": "error",
+    "@typescript-eslint/no-deprecated": "error",
+    "@typescript-eslint/no-duplicate-type-constituents": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-meaningless-void-operator": "error",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksVoidReturn": {
+          "arguments": false
+        }
+      }
+    ],
+    "@typescript-eslint/no-misused-spread": "error",
+    "@typescript-eslint/no-mixed-enums": "error",
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
+    "@typescript-eslint/no-unnecessary-condition": "error",
+    "@typescript-eslint/no-unnecessary-template-expression": "error",
+    "@typescript-eslint/no-unnecessary-type-arguments": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unnecessary-type-conversion": "error",
+    "@typescript-eslint/no-unnecessary-type-parameters": "error",
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-enum-comparison": "error",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-unsafe-unary-minus": "error",
+    "no-throw-literal": "off",
+    "@typescript-eslint/only-throw-error": "error",
+    "prefer-promise-reject-errors": "off",
+    "@typescript-eslint/prefer-promise-reject-errors": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-return-this-type": "error",
+    "@typescript-eslint/related-getter-setter-pairs": "error",
+    "require-await": "off",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": false,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNever": false,
+        "allowNullish": false,
+        "allowNumber": false,
+        "allowRegExp": false
+      }
+    ],
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": [
+      "error",
+      "error-handling-correctness-only"
+    ],
+    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+    "dot-notation": "off",
+    "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/non-nullable-type-assertion-style": "error",
+    "@typescript-eslint/prefer-find": "error",
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-regexp-exec": "error",
+    "@typescript-eslint/prefer-string-starts-ends-with": "error",
+    "@typescript-eslint/consistent-type-exports": [
+      "error",
+      {
+        "fixMixedExportsWithInlineTypeSpecifier": true
+      }
+    ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "fixStyle": "inline-type-imports"
+      }
+    ]
   },
   "languageOptions": {
     "globals": [
@@ -4451,9 +4735,8 @@ exports[`Extension .ts 1`] = `
     "ecmaVersion": 2024,
     "sourceType": "module",
     "parserOptions": {
-      "ecmaFeatures": {
-        "globalReturn": true
-      }
+      "projectService": true,
+      "tsconfigRootDir": "<rootDir>"
     },
     "parser": "[Parser typescript-eslint/parser]"
   },
@@ -5478,6 +5761,10 @@ exports[`Extension .vue 1`] = `
     "ecmaVersion": "latest",
     "sourceType": "module",
     "parserOptions": {
+      "extraFileExtensions": [
+        ".svelte",
+        ".vue"
+      ],
       "parser": "[Parser typescript-eslint/parser]"
     },
     "parser": "[Parser vue-eslint-parser]"
@@ -6638,6 +6925,7 @@ exports[`Package @forsakringskassan/eslint-config-jest 1`] = `
     "jest/prefer-to-contain": "error",
     "jest/prefer-to-have-length": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
     "jest/consistent-test-it": [
       "error",
       {
@@ -6670,7 +6958,8 @@ exports[`Package @forsakringskassan/eslint-config-svelte 1`] = `
     "parser": "[Parser svelte-eslint-parser]",
     "parserOptions": {
       "extraFileExtensions": [
-        ".svelte"
+        ".svelte",
+        ".vue"
       ],
       "parser": "[Parser typescript-eslint/parser]"
     },
@@ -6742,6 +7031,12 @@ exports[`Package @forsakringskassan/eslint-config-typescript 1`] = `
   ],
   "languageOptions": {
     "parser": "[Parser typescript-eslint/parser]",
+    "parserOptions": {
+      "extraFileExtensions": [
+        ".svelte",
+        ".vue"
+      ]
+    },
     "sourceType": "module"
   },
   "plugins": {
@@ -6867,6 +7162,151 @@ exports[`Package @forsakringskassan/eslint-config-typescript 1`] = `
 }
 `;
 
+exports[`Package @forsakringskassan/eslint-config-typescript-typeinfo 1`] = `
+{
+  "name": "@forsakringskassan/eslint-config-typescript-typeinfo",
+  "files": [
+    "**/*.{ts,cts,mts}"
+  ],
+  "languageOptions": {
+    "parser": "[Parser typescript-eslint/parser]",
+    "sourceType": "module",
+    "parserOptions": {
+      "projectService": true,
+      "tsconfigRootDir": "<rootDir>"
+    }
+  },
+  "plugins": {
+    "@typescript-eslint": "[Plugin @typescript-eslint/eslint-plugin]"
+  },
+  "rules": {
+    "constructor-super": "off",
+    "getter-return": "off",
+    "no-class-assign": "off",
+    "no-const-assign": "off",
+    "no-dupe-args": "off",
+    "no-dupe-class-members": "off",
+    "no-dupe-keys": "off",
+    "no-func-assign": "off",
+    "no-import-assign": "off",
+    "no-new-native-nonconstructor": "off",
+    "no-new-symbol": "off",
+    "no-obj-calls": "off",
+    "no-redeclare": "off",
+    "no-setter-return": "off",
+    "no-this-before-super": "off",
+    "no-undef": "off",
+    "no-unreachable": "off",
+    "no-unsafe-negation": "off",
+    "no-var": "error",
+    "no-with": "off",
+    "prefer-const": "error",
+    "prefer-rest-params": "error",
+    "prefer-spread": "error",
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/no-array-delete": "error",
+    "@typescript-eslint/no-base-to-string": "error",
+    "@typescript-eslint/no-confusing-void-expression": "error",
+    "@typescript-eslint/no-deprecated": "error",
+    "@typescript-eslint/no-duplicate-type-constituents": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-for-in-array": "error",
+    "no-implied-eval": "off",
+    "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-meaningless-void-operator": "error",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksVoidReturn": {
+          "arguments": false
+        }
+      }
+    ],
+    "@typescript-eslint/no-misused-spread": "error",
+    "@typescript-eslint/no-mixed-enums": "error",
+    "@typescript-eslint/no-redundant-type-constituents": "off",
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
+    "@typescript-eslint/no-unnecessary-condition": "error",
+    "@typescript-eslint/no-unnecessary-template-expression": "error",
+    "@typescript-eslint/no-unnecessary-type-arguments": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unnecessary-type-conversion": "error",
+    "@typescript-eslint/no-unnecessary-type-parameters": "error",
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-enum-comparison": "error",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-unsafe-unary-minus": "error",
+    "no-throw-literal": "off",
+    "@typescript-eslint/only-throw-error": "error",
+    "prefer-promise-reject-errors": "off",
+    "@typescript-eslint/prefer-promise-reject-errors": "error",
+    "@typescript-eslint/prefer-reduce-type-parameter": "error",
+    "@typescript-eslint/prefer-return-this-type": "error",
+    "@typescript-eslint/related-getter-setter-pairs": "error",
+    "require-await": "off",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNullish": false,
+        "allowNumberAndString": false,
+        "allowRegExp": false
+      }
+    ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {
+        "allowAny": false,
+        "allowBoolean": false,
+        "allowNever": false,
+        "allowNullish": false,
+        "allowNumber": false,
+        "allowRegExp": false
+      }
+    ],
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": [
+      "error",
+      "error-handling-correctness-only"
+    ],
+    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
+    "dot-notation": "off",
+    "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/non-nullable-type-assertion-style": "error",
+    "@typescript-eslint/prefer-find": "error",
+    "@typescript-eslint/prefer-includes": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
+    "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-regexp-exec": "error",
+    "@typescript-eslint/prefer-string-starts-ends-with": "error",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/consistent-type-definitions": [
+      "error",
+      "interface"
+    ],
+    "@typescript-eslint/consistent-type-exports": [
+      "error",
+      {
+        "fixMixedExportsWithInlineTypeSpecifier": true
+      }
+    ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "fixStyle": "inline-type-imports"
+      }
+    ],
+    "tsdoc/syntax": "error"
+  }
+}
+`;
+
 exports[`Package @forsakringskassan/eslint-config-vue 1`] = `
 {
   "name": "@forsakringskassan/eslint-config-vue",
@@ -6876,6 +7316,10 @@ exports[`Package @forsakringskassan/eslint-config-vue 1`] = `
   "languageOptions": {
     "parser": "[Parser vue-eslint-parser]",
     "parserOptions": {
+      "extraFileExtensions": [
+        ".svelte",
+        ".vue"
+      ],
       "parser": "[Parser typescript-eslint/parser]"
     },
     "sourceType": "module",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import cypressConfig from "./packages/eslint-config-cypress/index.mjs";
 import jestConfig from "./packages/eslint-config-jest/index.mjs";
 import svelteConfig from "./packages/eslint-config-svelte/index.mjs";
 import typescriptConfig from "./packages/eslint-config-typescript/index.mjs";
+import typeinfoConfig from "./packages/eslint-config-typescript-typeinfo/index.mjs";
 import vueConfig from "./packages/eslint-config-vue/index.mjs";
 
 export default [
@@ -23,6 +24,10 @@ export default [
         files: ["packages/eslint-config-cli/example.js"],
     }),
     typescriptConfig(),
+    typeinfoConfig(import.meta.dirname, {
+        files: ["packages/**/*.{ts,vue}"],
+        ignores: ["**/*.d.ts", "**/*.cy.ts", "**/*.spec.ts"],
+    }),
     vueConfig(),
     jestConfig(),
     cypressConfig(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -935,6 +935,10 @@
       "resolved": "packages/eslint-config-typescript",
       "link": true
     },
+    "node_modules/@forsakringskassan/eslint-config-typescript-typeinfo": {
+      "resolved": "packages/eslint-config-typescript-typeinfo",
+      "link": true
+    },
     "node_modules/@forsakringskassan/eslint-config-vue": {
       "resolved": "packages/eslint-config-vue",
       "link": true
@@ -16978,6 +16982,21 @@
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-tsdoc": "0.4.0",
+        "typescript-eslint": "8.43.0"
+      },
+      "engines": {
+        "node": ">= 22.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0",
+        "typescript": "^3.0.1 || ^4.0.2 || ^5.0.2"
+      }
+    },
+    "packages/eslint-config-typescript-typeinfo": {
+      "name": "@forsakringskassan/eslint-config-typescript-typeinfo",
+      "version": "13.0.0",
+      "license": "MIT",
+      "dependencies": {
         "typescript-eslint": "8.43.0"
       },
       "engines": {

--- a/packages/eslint-config-jest/index.mjs
+++ b/packages/eslint-config-jest/index.mjs
@@ -50,6 +50,10 @@ const config = defineConfig({
         ...style.rules,
 
         "@typescript-eslint/no-non-null-assertion": "off",
+
+        /* jest functions often use "any" */
+        "@typescript-eslint/no-unsafe-assignment": "off",
+
         "jest/consistent-test-it": ["error", { fn: "it" }],
         "jest/no-alias-methods": "error",
         "jest/no-disabled-tests": "warn",

--- a/packages/eslint-config-svelte/index.mjs
+++ b/packages/eslint-config-svelte/index.mjs
@@ -39,7 +39,7 @@ const config = defineConfig({
     languageOptions: {
         parser: svelteParser,
         parserOptions: {
-            extraFileExtensions: [".svelte"],
+            extraFileExtensions: [".svelte", ".vue"],
             parser: tseParser,
         },
         globals: {

--- a/packages/eslint-config-typescript-typeinfo/index.d.mts
+++ b/packages/eslint-config-typescript-typeinfo/index.d.mts
@@ -1,0 +1,8 @@
+import { Linter } from "eslint";
+
+declare const config: (
+    tsconfigRootDir?: string | URL,
+    config?: Linter.Config,
+) => Linter.Config;
+
+export default config;

--- a/packages/eslint-config-typescript-typeinfo/index.mjs
+++ b/packages/eslint-config-typescript-typeinfo/index.mjs
@@ -1,0 +1,117 @@
+import {
+    configs as tseConfig,
+    parser as tseParser,
+    plugin as tsePlugin,
+} from "typescript-eslint";
+
+/**
+ * @typedef {import("eslint").Linter.Config} Config
+ */
+
+/**
+ * @param {Config} config
+ * @returns {Config}
+ */
+function defineConfig(config) {
+    return config;
+}
+
+/**
+ * @param {Config} result
+ * @param {Config} it
+ * @returns {Config}
+ */
+function merge(result, it) {
+    return {
+        ...result,
+        ...it,
+        languageOptions: { ...result.languageOptions, ...it.languageOptions },
+        plugins: { ...result.plugins, ...it.plugins },
+        rules: { ...result.rules, ...it.rules },
+    };
+}
+
+const strict = tseConfig.strictTypeCheckedOnly.reduce(merge, {});
+const stylistic = tseConfig.stylisticTypeCheckedOnly.reduce(merge, {});
+
+const config = defineConfig({
+    name: "@forsakringskassan/eslint-config-typescript-typeinfo",
+    files: ["**/*.{ts,cts,mts}"],
+
+    languageOptions: {
+        parser: tseParser,
+        sourceType: "module",
+        parserOptions: {
+            projectService: true,
+        },
+    },
+
+    plugins: {
+        "@typescript-eslint": tsePlugin,
+    },
+
+    rules: {
+        ...strict.rules,
+        ...stylistic.rules,
+
+        /* no-explicit-any is enabled and for now this rule is a bit to tedious
+         * to actually help */
+        "@typescript-eslint/no-unsafe-member-access": "off",
+
+        "@typescript-eslint/no-inferrable-types": "off",
+
+        /* prefer interface over type = { .. } */
+        "@typescript-eslint/consistent-type-definitions": [
+            "error",
+            "interface",
+        ],
+
+        /* enforce usage of "type" with export/import */
+        "@typescript-eslint/consistent-type-exports": [
+            "error",
+            {
+                fixMixedExportsWithInlineTypeSpecifier: true,
+            },
+        ],
+        "@typescript-eslint/consistent-type-imports": [
+            "error",
+            {
+                fixStyle: "inline-type-imports",
+            },
+        ],
+
+        "@typescript-eslint/no-misused-promises": [
+            "error",
+            {
+                checksVoidReturn: {
+                    /* it is useful to use "async () => { ... }" even if the
+                     * receiving function doesn't really handle the promise */
+                    arguments: false,
+                },
+            },
+        ],
+
+        /* allow constructs such as `unknown | null`, while `unknown` does
+         * override `null` it can still serve as a self-documenting type to
+         * signal that `null` has a special meaning. It also helps when the type
+         * is to be replaced with a better type later. */
+        "@typescript-eslint/no-redundant-type-constituents": "off",
+
+        /* allow expr === false */
+        "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
+
+        "tsdoc/syntax": "error",
+    },
+});
+
+/**
+ * @param {string | URL} [tsconfigRootDir]
+ * @param {Config} [override]
+ * @returns {Config}
+ */
+export default (tsconfigrootDir, override) => {
+    const merged = merge(config, override ?? {});
+    merged.languageOptions.parserOptions.tsconfigRootDir =
+        tsconfigrootDir ?? process.cwd();
+    return merged;
+};

--- a/packages/eslint-config-typescript-typeinfo/package.json
+++ b/packages/eslint-config-typescript-typeinfo/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@forsakringskassan/eslint-config-typescript-typeinfo",
+  "version": "13.0.0",
+  "description": "Försäkringskassans eslint shareable typescript config with typeinfo",
+  "keywords": [
+    "eslint"
+  ],
+  "homepage": "https://github.com/Forsakringskassan/eslint-config",
+  "bugs": "https://github.com/Forsakringskassan/eslint-config/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Forsakringskassan/eslint-config.git",
+    "directory": "packages/eslint-config-typescript-typeinfo"
+  },
+  "license": "MIT",
+  "author": "Försäkringskassan",
+  "main": "index.mjs",
+  "files": [
+    "index.mjs",
+    "index.d.mts"
+  ],
+  "dependencies": {
+    "typescript-eslint": "8.43.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0",
+    "typescript": "^3.0.1 || ^4.0.2 || ^5.0.2"
+  },
+  "engines": {
+    "node": ">= 22.0"
+  }
+}

--- a/packages/eslint-config-typescript/example.ts
+++ b/packages/eslint-config-typescript/example.ts
@@ -98,3 +98,11 @@ export function withManyParams(
 ): number[] {
     return [a, b, c, d, e];
 }
+
+export function fnExpectingVoidCallback(cb: () => void): void {
+    cb();
+}
+
+fnExpectingVoidCallback(async () => {
+    await Promise.resolve();
+});

--- a/packages/eslint-config-typescript/index.mjs
+++ b/packages/eslint-config-typescript/index.mjs
@@ -41,6 +41,9 @@ const config = defineConfig({
 
     languageOptions: {
         parser: tseParser,
+        parserOptions: {
+            extraFileExtensions: [".svelte", ".vue"],
+        },
         sourceType: "module",
     },
 

--- a/packages/eslint-config-vue/exampleComposition.vue
+++ b/packages/eslint-config-vue/exampleComposition.vue
@@ -10,9 +10,11 @@ function increment(): void {
 }
 
 // lifecycle hooks
-onMounted(() => {
+onMounted(async () => {
+    await Promise.resolve();
+
     /* eslint-disable-next-line no-console -- expected to log */
-    console.log(`The initial count is ${count.value}.`);
+    console.log(`The initial count is ${String(count.value)}.`);
 });
 </script>
 

--- a/packages/eslint-config-vue/index.mjs
+++ b/packages/eslint-config-vue/index.mjs
@@ -52,6 +52,7 @@ const config = defineConfig({
     languageOptions: {
         parser: recommended.languageOptions.parser,
         parserOptions: {
+            extraFileExtensions: [".svelte", ".vue"],
             parser: tseParser,
         },
         sourceType: "module",


### PR DESCRIPTION
Borde dragit med detta innan breaking men det blir breaking eftersom man måste passa in `import.meta.dirname` nu, kör det som en `fix` nu istället men borde nog varit `feat` annars.

~Stänger av lite nya sonarjs regler som kom in när `eslint-plugin-sonarjs` bumpades, baserar det på `@html-validate/eslint-config` men vi kan väl köra lite med det och sen se över vilka som är rimliga?~
