### PR TITLE
feat: cli config handles workspaces configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ import svelteConfig from "@forsakringskassan/eslint-config-svelte";
 import typescriptConfig from "@forsakringskassan/eslint-config-typescript";
 import typeinfoConfig from "@forsakringskassan/eslint-config-typescript-typeinfo";
 import vueConfig from "@forsakringskassan/eslint-config-vue";
+import pkg from "./package.json" with { type: "json" };
 
 export default [
     {
@@ -59,7 +60,7 @@ export default [
 
     ...defaultConfig,
 
-    cliConfig(),
+    cliConfig(pkg),
     typescriptConfig(),
     typeinfoConfig(import.meta.dirname),
     vueConfig(),
@@ -73,7 +74,7 @@ Konfigurationsfabriker tar ett optional object för att anpassa filer som ska ma
 
 ```ts
 export default [
-    cliConfig({
+    typescriptConfig({
         files: ["..."],
     }),
 ];

--- a/config.test.mjs
+++ b/config.test.mjs
@@ -1,7 +1,8 @@
-import test from "node:test";
+import test, { describe } from "node:test";
 import globals from "globals";
 import { minimatch } from "minimatch";
 import defaultConfig from "./packages/eslint-config/index.mjs";
+import cliConfig from "./packages/eslint-config-cli/index.mjs";
 import cypressConfig from "./packages/eslint-config-cypress/index.mjs";
 import jestConfig from "./packages/eslint-config-jest/index.mjs";
 import svelteConfig from "./packages/eslint-config-svelte/index.mjs";
@@ -112,6 +113,15 @@ for (const pkg of packages) {
         t.assert.snapshot(serialize(config));
     });
 }
+
+describe("workspace configuration", () => {
+    test(`@forsakringskassan/eslint-config-cli should handle workspace configuration`, async (t) => {
+        const config = cliConfig({
+            workspaces: ["docs", "packages/*"],
+        });
+        t.assert.snapshot(config.files);
+    });
+});
 
 const config = [
     ...defaultConfig,

--- a/config.test.mjs.snapshot
+++ b/config.test.mjs.snapshot
@@ -9893,8 +9893,7 @@ exports[`Package @forsakringskassan/eslint-config-cli 1`] = `
   "name": "@forsakringskassan/eslint-config-cli",
   "files": [
     "*.{js,ts,cjs,mjs}",
-    "**/scripts/*.{js,ts,cjs,mjs}",
-    "{internal,packages}/*/*.{js,ts,cjs,mjs}"
+    "**/scripts/*.{js,ts,cjs,mjs}"
   ],
   "languageOptions": {
     "globals": [
@@ -10790,4 +10789,13 @@ exports[`Package @forsakringskassan/eslint-config-vue 1`] = `
     "vue/valid-v-text": "error"
   }
 }
+`;
+
+exports[`workspace configuration > @forsakringskassan/eslint-config-cli should handle workspace configuration 1`] = `
+[
+  "*.{js,ts,cjs,mjs}",
+  "**/scripts/*.{js,ts,cjs,mjs}",
+  "docs/*.{js,ts,cjs,mjs}",
+  "packages/*/*.{js,ts,cjs,mjs}"
+]
 `;

--- a/packages/eslint-config-cli/index.d.mts
+++ b/packages/eslint-config-cli/index.d.mts
@@ -1,5 +1,7 @@
 import { Linter } from "eslint";
 
-declare const config: (config?: Linter.Config) => Linter.Config;
-
-export default config;
+export default function cliConfig(config?: Linter.Config): Linter.Config;
+export default function cliConfig(
+    pkg: { workspaces?: string[] },
+    config?: Linter.Config,
+): Linter.Config;

--- a/packages/eslint-config-cli/index.mjs
+++ b/packages/eslint-config-cli/index.mjs
@@ -1,7 +1,12 @@
+import path from "node:path/posix";
 import globals from "globals";
 
 /**
  * @typedef {import("eslint").Linter.Config} Config
+ */
+
+/**
+ * @typedef {{ workspaces?: string[] }} PackageJson
  */
 
 /**
@@ -29,11 +34,7 @@ function merge(result, it) {
 
 const defaultConfig = defineConfig({
     name: "@forsakringskassan/eslint-config-cli",
-    files: [
-        "*.{js,ts,cjs,mjs}",
-        "**/scripts/*.{js,ts,cjs,mjs}",
-        "{internal,packages}/*/*.{js,ts,cjs,mjs}",
-    ],
+    files: ["*.{js,ts,cjs,mjs}", "**/scripts/*.{js,ts,cjs,mjs}"],
     languageOptions: {
         globals: {
             ...globals.node,
@@ -46,8 +47,64 @@ const defaultConfig = defineConfig({
 });
 
 /**
- * @param {Config} [override]
+ * @param {PackageJson | undefined} pkg
  * @returns {Config}
  */
-const config = (override) => merge(defaultConfig, override ?? {});
-export default config;
+function getDefaultConfig(pkg) {
+    const files = [...defaultConfig.files];
+    if (pkg?.workspaces) {
+        for (const workspace of pkg.workspaces) {
+            files.push(path.join(workspace, files[0]));
+        }
+    }
+    return {
+        ...defaultConfig,
+        files,
+    };
+}
+
+/**
+ * @param {Config | PackageJson} value
+ * @returns {value is PackageJson}
+ */
+function isPkg(value) {
+    if (!value) {
+        return false;
+    }
+    /* handle imported package.json without workspaces */
+    if (Object.hasOwn(value, "name") && Object.hasOwn(value, "version")) {
+        return true;
+    }
+    /* handle handcrafted object with only workspaces set */
+    if (Object.hasOwn(value, "workspaces")) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @param {[config?: Config] | [pkg: PackageJson, config?: Config]} [params]
+ * @returns {[pkg: PackageJson | undefined, config: Config | undefined]}
+ */
+function unpackArgs(params) {
+    if (params.length >= 2) {
+        return params;
+    }
+    if (params.length === 0) {
+        return [undefined, undefined];
+    }
+    const param = params[0];
+    if (isPkg(param)) {
+        return [param, undefined];
+    }
+    return [undefined, param];
+}
+
+/**
+ * @param {[config: Config] | [pkg: PackageJson, config?: Config]} [params]
+ * @returns {Config}
+ */
+export default function cliConfig(...params) {
+    const [pkg, override] = unpackArgs(params);
+    return merge(getDefaultConfig(pkg), override ?? {});
+}


### PR DESCRIPTION
Det är väl egentligen kanske brytande, känner att det är så få repon som kommer påverkas att vi inte behöver göra en breaking eller tycker ni vi ska peta ut en ny major?

För icke-monorepon:

* `pkg` parametern är optional, det fungerar både att inte passa några parametrar alls eller att skicka in en config override, precis som tidigare.
* de får inte längre med sig globbar så som `packages/*/*.js`, men eftersom de inte är monorepon så kvittar det.

För monorepon:

* Det är troligt men inte garanterat att eslint kommer faila efter ändringen, det beror ju på om repot har config-filer som gör något som triggar eslint. Mest troligt är väl om det ligger ett bygg-script som använder `console.log()` (tillåtet under cli-config men inte under default-config).
* Här behöver man nu passa in package.json filen (eller egentligen bara `{ workspaces }` delen men enklare att bara importera `package.json` and be done with it.

Bakgrunden är att det är väldigt knöligt att hantera alla globbar, nu har vi hårdkodat `{internal,packages}' men vi flera av de större komponentbiblioteken måste vi ändra då vi har fler kataloger, community har en djupare struktur osv.

Nu blir det automatiskt av att alla workspaces du konfigurerat i `package.json` får rätt globbar: `docs`, `examples/*`, `packages/public/*` osv bara fungerar out-of-the-box och kräver ingen anpassning i repots `eslint.config.mjs`.